### PR TITLE
Added support to load Tesseract Data from any location. (#57)

### DIFF
--- a/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
+++ b/SwiftyTesseract/SwiftyTesseract.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		62E3D1E22049FAAE0030AB11 /* IMG_1108.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */; };
 		8703EC8222032A54005B03EA /* MultipleInterwordSpaces.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */; };
 		8705C26E222ED10D0014DCAA /* NormalAndSmallFonts.jpg in Resources */ = {isa = PBXBuildFile; fileRef = 8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */; };
+		9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -91,6 +92,7 @@
 		62E3D1E12049FAAE0030AB11 /* IMG_1108.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = IMG_1108.jpg; sourceTree = "<group>"; };
 		8703EC8122032A54005B03EA /* MultipleInterwordSpaces.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = MultipleInterwordSpaces.jpg; sourceTree = "<group>"; };
 		8705C26C222EC9530014DCAA /* NormalAndSmallFonts.jpg */ = {isa = PBXFileReference; lastKnownFileType = image.jpeg; path = NormalAndSmallFonts.jpg; sourceTree = "<group>"; };
+		9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LanguageModelDataSource.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -123,6 +125,7 @@
 			isa = PBXGroup;
 			children = (
 				621E38542097A09000446A42 /* LanguageStringConverter.swift */,
+				9D5C241F244A229800D66FFE /* LanguageModelDataSource.swift */,
 			);
 			path = Protocols;
 			sourceTree = "<group>";
@@ -398,6 +401,7 @@
 				62DF38BC2066AC01008F0476 /* RecognitionLanguage.swift in Sources */,
 				62DF38BB2066AC01008F0476 /* TesseractVariableName.swift in Sources */,
 				6271A4C92047A360005DB23B /* SwiftyTesseract.swift in Sources */,
+				9D5C2420244A229800D66FFE /* LanguageModelDataSource.swift in Sources */,
 				62DF38BA2066AC01008F0476 /* EngineMode.swift in Sources */,
 				621E38552097A09000446A42 /* LanguageStringConverter.swift in Sources */,
 				62DF38BF2066AC2A008F0476 /* String+Extensions.swift in Sources */,

--- a/SwiftyTesseract/SwiftyTesseract/Extensions/Bundle+pathToTrainedData.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Extensions/Bundle+pathToTrainedData.swift
@@ -8,8 +8,8 @@
 
 import Foundation
 
-extension Bundle {
-  var pathToTrainedData: String {
+extension Bundle: LanguageModelDataSource {
+  public var pathToTrainedData: String {
     return bundleURL.appendingPathComponent("tessdata").path
   }
 }

--- a/SwiftyTesseract/SwiftyTesseract/Protocols/LanguageModelDataSource.swift
+++ b/SwiftyTesseract/SwiftyTesseract/Protocols/LanguageModelDataSource.swift
@@ -1,0 +1,13 @@
+//
+//  LanguageModelDataSource.swift
+//  SwiftyTesseract
+//
+//  Created by Antonio Zaitoun on 17/04/2020.
+//  Copyright © 2020 Steven Sherry. All rights reserved.
+//
+
+import Foundation
+
+public protocol LanguageModelDataSource {
+  var pathToTrainedData: String { get }
+}


### PR DESCRIPTION
* Added support to load Tesseract Data from any location.

## Code

- Replace parameter name in initializer from `bundle` to `dataSource`.
- Removed any use of `Bundle` and replaced it with `LanguageModelDataSource`.

## Tests
- Added a unit test which copies the english trained data from the bundle into the documents directory under /tessdata. Then creates a SwiftyTesseract instance using a data source which uses the documents directory location.

* Marked old initializers as deprecated

* Fixed unit test.